### PR TITLE
Ship an explicit module descriptor in microprofile-jwt-auth-api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -55,5 +55,45 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!--
+                        The module descriptor is compiled in a dedicated execution, patched onto the
+                        already compiled classes. This keeps the main compilation unchanged (class path)
+                        and avoids requiring the OSGi/bnd annotation jars referenced by package-info.java,
+                        which are compile-time only and ship no module descriptor.
+                    -->
+                    <execution>
+                        <id>compile-module-info</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <!-- module-info requires at least Java 9; the other classes stay on the project baseline. -->
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/module-info</compileSourceRoot>
+                            </compileSourceRoots>
+                            <compilerArgs>
+                                <arg>--patch-module</arg>
+                                <arg>org.eclipse.microprofile.jwt=${project.build.outputDirectory}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <legacyMode>true</legacyMode>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,9 +90,35 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <!--
+                        Keep javadoc in class path mode: a module-info.java at the root of a source path would switch
+                        it to module mode, so only the regular sources are documented.
+                    -->
                     <legacyMode>true</legacyMode>
+                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Register the descriptor source root only once compilation is over, so that the
+                        sources jar ships module-info.java while the default compilation keeps ignoring it.
+                    -->
+                    <execution>
+                        <id>add-module-info-source</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/module-info</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -68,7 +68,7 @@
                     -->
                     <execution>
                         <id>compile-module-info</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -20,16 +20,10 @@
 
 /**
  * MicroProfile JWT Auth API.
- *
- * <p>
- * {@code Claims} declares {@code jakarta.json.JsonObject} as the type of several standard claims
- * ({@code address}, {@code jwk}, {@code sub_jwk}), {@code @Claim} is a
- * {@code jakarta.inject.Qualifier} with {@code @Nonbinding} members and {@code ClaimLiteral} extends
- * {@code AnnotationLiteral}, so the JSON-P, CDI and Inject modules are required transitively.
  */
 module org.eclipse.microprofile.jwt {
-    requires transitive jakarta.cdi;
-    requires transitive jakarta.inject;
+    requires static transitive jakarta.cdi;
+    requires static transitive jakarta.inject;
     requires transitive jakarta.json;
 
     exports org.eclipse.microprofile.auth;

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -22,7 +22,8 @@
  * MicroProfile JWT Auth API.
  *
  * <p>
- * {@code Claims} and {@code JsonWebToken} expose {@code jakarta.json} types, {@code @Claim} is a
+ * {@code Claims} declares {@code jakarta.json.JsonObject} as the type of several standard claims
+ * ({@code address}, {@code jwk}, {@code sub_jwk}), {@code @Claim} is a
  * {@code jakarta.inject.Qualifier} with {@code @Nonbinding} members and {@code ClaimLiteral} extends
  * {@code AnnotationLiteral}, so the JSON-P, CDI and Inject modules are required transitively.
  */

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * MicroProfile JWT Auth API.
+ *
+ * <p>
+ * {@code Claims} and {@code JsonWebToken} expose {@code jakarta.json} types, {@code @Claim} is a
+ * {@code jakarta.inject.Qualifier} with {@code @Nonbinding} members and {@code ClaimLiteral} extends
+ * {@code AnnotationLiteral}, so the JSON-P, CDI and Inject modules are required transitively.
+ */
+module org.eclipse.microprofile.jwt {
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.inject;
+    requires transitive jakarta.json;
+
+    exports org.eclipse.microprofile.auth;
+    exports org.eclipse.microprofile.jwt;
+    exports org.eclipse.microprofile.jwt.config;
+}


### PR DESCRIPTION
Fixes #352

Adds an explicit `module-info.java` to `microprofile-jwt-auth-api` so the MicroProfile JWT Auth API can be consumed as a proper Java module instead of an automatic one (context: [mailing-list thread](https://groups.google.com/g/microprofile/c/h2e3FicNw5k), same change proposed for every affected MicroProfile API).

The change is designed to be **mergeable in the next minor release without touching the Java 8 baseline**: the API classes are still compiled with `--release 8`, and the only Java 9 element is the `module-info.class` itself, compiled by a dedicated execution (the approach used by e.g. SLF4J 2.x). Moving to `microprofile-parent` 3.x / Java 11 is a separate decision for the project; if and when it happens, the special-casing below disappears and the wiring becomes identical to the Health and Metrics PRs.

### The descriptor

```java
module org.eclipse.microprofile.jwt {
    requires static transitive jakarta.cdi;
    requires static transitive jakarta.inject;
    requires transitive jakarta.json;

    exports org.eclipse.microprofile.auth;
    exports org.eclipse.microprofile.jwt;
    exports org.eclipse.microprofile.jwt.config;
}
```

The module name follows the `org.eclipse.microprofile.<spec>` convention (reverse-DNS of the root package, as already used by the Config API's `Automatic-Module-Name` and by the OpenAPI API's existing descriptor). `jakarta.json` is a hard dependency (three `Claims` enum constants reference `JsonObject.class` directly) and stays `requires transitive`. The CDI and Inject modules are only referenced by the `@Claim` qualifier and its `ClaimLiteral`; `JsonWebToken`, `Claims` and the `config` package do not depend on them. They are therefore declared `requires static transitive`:

- `static`: optional at resolution time, so the module resolves on a module path without a CDI container. Whenever the annotations are actually used at run time it is through a CDI container, whose own module `requires` the Jakarta modules and therefore resolves them.
- `transitive`: when they are resolved, a module using `@Claim` reads `jakarta.cdi` and `jakarta.inject` implicitly, which is needed for the meta-annotations and the `AnnotationLiteral` supertypes to be resolvable from that module.

The same trade-off is applied to the other MicroProfile APIs whose Jakarta dependency is annotation-only (see the discussion on microprofile/microprofile-health#344, microprofile/microprofile-metrics#805 and microprofile/microprofile-fault-tolerance#660). The module Javadoc is deliberately kept to a one-liner; this rationale lives here instead.

### Build changes (`api/pom.xml`)

- The descriptor lives in `src/main/module-info/` and is compiled by a dedicated `maven-compiler-plugin` execution patched onto the already compiled classes (`--patch-module`). The main compilation is left untouched on the class path, and the descriptor does not have to `requires` the OSGi/bnd annotation jars used by `package-info.java`, which are compile-time only and ship no module descriptor of their own.
- The descriptor source root is registered with `build-helper-maven-plugin` at `prepare-package` (after compilation) so that the attached `*-sources.jar` ships `module-info.java` alongside the other sources.
- `maven-javadoc-plugin` is kept in class path mode (`legacyMode`) with an explicit `sourcepath` limited to `src/main/java`: javadoc would otherwise switch to module mode as soon as it finds a `module-info.java` at the root of a source path.
- The project baseline is Java 8 (`microprofile-parent` 2.x), so the dedicated execution uses `--release 9` — the only Java 9 exception in the build, so that this can land in the next minor release without waiting for a Java baseline bump. Should the project move to `microprofile-parent` 3.x (Java 11), this special case simply goes away. The resulting `module-info.class` (class file version 53) sits at the jar root next to Java 8 classes — the same layout used by e.g. SLF4J 2.x; a Java 8 runtime never loads `module-info` and OSGi/bnd ignore it. Packaging it as `META-INF/versions/9/` (multi-release) is possible too if the project prefers.

### Verification

- `mvn install -DskipTests` on the whole reactor passes.
- `jar --describe-module` on the built jar shows the descriptor above; OSGi headers (`Bundle-SymbolicName`, `Export-Package`, `Import-Package`) generated by bnd are unchanged.
- `java --module-path <api jar + compile deps> --describe-module org.eclipse.microprofile.jwt` resolves the module graph successfully (with only `jakarta.json` next to the api jar it resolves as well, the CDI/Inject modules being optional).
- The `*-sources.jar` contains `module-info.java`; the `*-javadoc.jar` is unchanged.
